### PR TITLE
fix path of pod of perl*

### DIFF
--- a/helm-perldoc.el
+++ b/helm-perldoc.el
@@ -55,7 +55,7 @@
       (mapconcat 'identity
                  (list
                   "print for ExtUtils::Installed->new->modules;"
-                  "opendir $dh, File::Spec->catfile($Config{privlibexp}, \"pod\");"
+                  "opendir $dh, File::Spec->catfile($Config{installprivlib}, $^O =~ /^(?:cygwin|darwin|VMS|MSWin32)$/ ? \"pods\" : \"pod\");"
                   "while (readdir $dh) { m/^(.+)\.pod$/ and print $1}"
                   "closedir $dh;")
                  " "))


### PR DESCRIPTION
installed directory of perl*.pod differs from operating system...
http://perl5.git.perl.org/perl.git/blob/e2a4306ace4a19cb3a434e4eb9fedad6ff1248b4:/installperl#l531
