### PR TITLE
ignore current directory in collect-installed-modules

### DIFF
--- a/helm-perldoc.el
+++ b/helm-perldoc.el
@@ -54,7 +54,7 @@
       "-le"
       (mapconcat 'identity
                  (list
-                  "print for ExtUtils::Installed->new->modules;"
+                  "print for ExtUtils::Installed->new(inc_override => [grep(!/^\.$/, @INC)])->modules;"
                   "opendir $dh, File::Spec->catfile($Config{privlibexp}, \"pod\");"
                   "while (readdir $dh) { m/^(.+)\.pod$/ and print $1}"
                   "closedir $dh;")


### PR DESCRIPTION
ExtUtils::Installed searches modules recursively from `@INC` directories, so it takes much CPU and times if it runs at `/`, `~/`, and the like.
I think it shoud ignore "current directory".
https://github.com/hirose31/list-installed-perl-modules/blob/81b5cf6194e5ed748e69f847db60d5c4ee96a61b/list-installed-perl-modules#L30
anyway, modules on irregular path (ex. installed by `cpanm -l local ...`) couldn't open by `perldoc` command.
