### PR TITLE
fix ":buffer" keyword

### DIFF
--- a/helm-perldoc.el
+++ b/helm-perldoc.el
@@ -295,7 +295,7 @@
   (helm :sources '(helm-perldoc:imported-source
                    helm-perldoc:superclass-source
                    helm-perldoc:other-source)
-        :buffer (get-buffer-create "*helm-perldoc*")))
+        :buffer "*helm-perldoc*"))
 
 (provide 'helm-perldoc)
 


### PR DESCRIPTION
`helm-perldoc` passed created buffer to ":buffer" keyword. but it needs string value.
(it causes problems in `helm-resume` with prefix arg.)
